### PR TITLE
Add a path to an existing ca certificate for SMTP

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -38,7 +38,7 @@ SMTP_FROM_ADDRESS=notifications@example.com
 #SMTP_AUTH_METHOD=plain
 #SMTP_OPENSSL_VERIFY_MODE=peer
 #SMTP_ENABLE_STARTTLS_AUTO=true
-
+#SMTP_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Optional asset host for multi-server setups
 # CDN_HOST=assets.example.com

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,7 @@ Rails.application.configure do
     :authentication => ENV['SMTP_AUTH_METHOD'] || :plain,
     :openssl_verify_mode => ENV['SMTP_OPENSSL_VERIFY_MODE'] || 'peer',
     :enable_starttls_auto => ENV['SMTP_ENABLE_STARTTLS_AUTO'] || true,
+    :ca_file => ENV['SMTP_SSL_CERT_FILE'] || "/etc/ssl/certs/ca-certificates.crt",
   }
 
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
In order to get TLS peer verification working on my gandi.net SMTP settings, I need certificate from trusted Certificate Authorities to verify the server.
This change aim at configuring action mailer to use a default ca certificates file.

I use the provided docker-compose containers.
The default certificate authority certificate seems to dictated by ruby "OpenSSL::X509::DEFAULT_CERT_FILE"
```
root@masto:~# docker exec -ti mastodon_web_1 sh
/mastodon # ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'
/etc/ssl/cert.pem
```
The main issue is that it doesn't exists:
```
mastodon@masto:~$ docker exec -it mastodon_web_1 sh
/mastodon # file /etc/ssl/cert.pem
/etc/ssl/cert.pem: cannot open `/etc/ssl/cert.pem' (No such file or directory)
```